### PR TITLE
Fix ruby-growl adapter to work with new Growl protocol

### DIFF
--- a/lib/notify/ruby-growl.rb
+++ b/lib/notify/ruby-growl.rb
@@ -2,7 +2,8 @@ module Notify
   begin
     require 'ruby-growl'
 
-    @@growl = Growl.new 'localhost', 'ruby', 'GNTP'
+    @@growl = Growl.new 'localhost', 'ruby'
+    @@growl.add_notification 'notify'
     def self.notify(title, message, option = {})
       @@growl.notify 'notify', title, message, option[:priority] || 0, option[:sticky] || false
     end

--- a/lib/notify/ruby-growl.rb
+++ b/lib/notify/ruby-growl.rb
@@ -2,7 +2,7 @@ module Notify
   begin
     require 'ruby-growl'
 
-    @@growl = Growl.new 'localhost', 'ruby', ['notify']
+    @@growl = Growl.new 'localhost', 'ruby', 'GNTP'
     def self.notify(title, message, option = {})
       @@growl.notify 'notify', title, message, option[:priority] || 0, option[:sticky] || false
     end


### PR DESCRIPTION
At some point, Growl has changed their protocol methods, and `ruby-growl` has been [updated](https://github.com/drbrain/ruby-growl/commit/c9ca7e88313e84a2c16d7d3e3a6fe5626fa7bff1) as well. This commit resolves a protocol error that was causing the `earthquake` gem to fail on launch after a clean install.
