### PR TITLE
Fix #3, allow app_name in Growl notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ or
     require 'notify'
     Notify.notify "title", "message"
 
+Notify also allows passing in an app name to replace the default "ruby":
+
+    require 'notify'
+    Notify.notify "title", "message", { app_name: "My App" }
+
 Command
 ---------
 

--- a/lib/notify.rb
+++ b/lib/notify.rb
@@ -20,13 +20,18 @@ module Notify
 end
 
 dir = File.dirname(__FILE__)
-if ENV['NOTIFY']
-  require File.join(dir, "notify/#{ENV['NOTIFY']}")
-else
-  Dir[File.join(dir, "notify/*.rb")].each do |filename|
-    break if Notify.methods.include?(:notify)
-    require filename
+begin
+  if ENV['NOTIFY']
+    require File.join(dir, "notify/#{ENV['NOTIFY']}")
+  else
+    Dir[File.join(dir, "notify/*.rb")].each do |filename|
+      break if Notify.methods.include?(:notify)
+      require filename
+    end
   end
+rescue LoadError
+  # A safeguard against bad libraries or edge-case errors.
+  puts "Notify can't find the library specified."
 end
 
 module Notify

--- a/lib/notify/ruby-growl.rb
+++ b/lib/notify/ruby-growl.rb
@@ -2,9 +2,9 @@ module Notify
   begin
     require 'ruby-growl'
 
-    @@growl = Growl.new 'localhost', 'ruby'
-    @@growl.add_notification 'notify'
     def self.notify(title, message, option = {})
+      @@growl = Growl.new 'localhost', option[:app_name] || "ruby"
+      @@growl.add_notification 'notify'
       @@growl.notify 'notify', title, message, option[:priority] || 0, option[:sticky] || false
     end
   rescue LoadError

--- a/lib/notify/ruby_gntp.rb
+++ b/lib/notify/ruby_gntp.rb
@@ -3,7 +3,7 @@ module Notify
     require 'ruby_gntp'
 
     def self.notify(title, message, option = {})
-      GNTP.notify :app_name => "ruby", :title => title, :text => message, :icon => option[:icon] || "", :sticky => option[:sticky] || false
+      GNTP.notify :app_name => option[:app_name] || "ruby", :title => title, :text => message, :icon => option[:icon] || "", :sticky => option[:sticky] || false
     end
   rescue LoadError
   end


### PR DESCRIPTION
This PR fixes #3 and allows the inclusion of an app_name from `ruby-growl` and `ruby_gntp`.

The syntax is a simple passing in of an option:

``` ruby
Notify.notify "Title", "Message", { app_name: "My App" }
```

I've also updated the README as well.
