### PR TITLE
Rescue against library load errors (#8)

### DIFF
--- a/lib/notify.rb
+++ b/lib/notify.rb
@@ -20,13 +20,18 @@ module Notify
 end
 
 dir = File.dirname(__FILE__)
-if ENV['NOTIFY']
-  require File.join(dir, "notify/#{ENV['NOTIFY']}")
-else
-  Dir[File.join(dir, "notify/*.rb")].each do |filename|
-    break if Notify.methods.include?(:notify)
-    require filename
+begin
+  if ENV['NOTIFY']
+    require File.join(dir, "notify/#{ENV['NOTIFY']}")
+  else
+    Dir[File.join(dir, "notify/*.rb")].each do |filename|
+      break if Notify.methods.include?(:notify)
+      require filename
+    end
   end
+rescue LoadError
+  # A safeguard against bad libraries or edge-case errors.
+  puts "Notify can't find the library specified."
 end
 
 module Notify


### PR DESCRIPTION
This PR _should_ fix #8: I don't have a Windows computer to exactly replicate the steps on.

Notify will rescue from a `LoadError` and return "Notify can't find the library specified." In the case of `earthquake`, which was mentioned in the issue, it will continue running without crashing. Since the notification part of earthquake _isn't_ crucial, I think this is a good solution.

You can test this by running: 

```
> NOTIFY=foobar notify title message
     Notify can't find the library specified.
     title: message
```
