### PR TITLE
Do not pass icon options to notify-send when there are none

### DIFF
--- a/lib/notify/notify-send.rb
+++ b/lib/notify/notify-send.rb
@@ -1,8 +1,8 @@
 module Notify
   if which('notify-send')
     def self.notify(title, message, option = {})
-      iconargs = option.key?(:icon) ? ["-i", option[:icon]] : ["",""]
-      system 'notify-send', title, html_escape(message), iconargs[0], iconargs[1]
+      iconargs = option.key?(:icon) ? ["-i", option[:icon]] : []
+      system 'notify-send', title, html_escape(message), *iconargs
     end
   end
 end


### PR DESCRIPTION
Otherwise Ubuntu 12.10 notify-send exists with wrong number of arguments
